### PR TITLE
Use amx parameter to prevent flash memory problems

### DIFF
--- a/custom_components/goecharger/__init__.py
+++ b/custom_components/goecharger/__init__.py
@@ -171,7 +171,7 @@ async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:
         if len(chargerNameInput) > 0:
             _LOGGER.debug(f"set max_current for charger '{chargerNameInput}' to {maxCurrent}")
             try:
-                await hass.async_add_executor_job(hass.data[DOMAIN]["api"][chargerNameInput].setMaxCurrent, maxCurrent)
+                await hass.async_add_executor_job(hass.data[DOMAIN]["api"][chargerNameInput].setTmpMaxCurrent, maxCurrent)
             except KeyError:
                 _LOGGER.error(f"Charger with name '{chargerName}' not found!")
 
@@ -179,7 +179,7 @@ async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:
             for charger in hass.data[DOMAIN]["api"].keys():
                 try:
                     _LOGGER.debug(f"set max_current for charger '{charger}' to {maxCurrent}")
-                    await hass.async_add_executor_job(hass.data[DOMAIN]["api"][charger].setMaxCurrent, maxCurrent)
+                    await hass.async_add_executor_job(hass.data[DOMAIN]["api"][charger].setTmpMaxCurrent, maxCurrent)
                 except KeyError:
                     _LOGGER.error(f"Charger with name '{chargerName}' not found!")
 


### PR DESCRIPTION
Home Assistant can write new maxCurrent value so often that the flash memory of charger can be broken.
https://github.com/goecharger/go-eCharger-API-v1/blob/master/go-eCharger%20API%20v1%20EN.md
amx 	uint8_t 	Ampere value for the PWM signaling in whole ampere of 6-32A Will not be written on flash but acts like you set amp instead. Only on the next reboot, the amp value will be restored to the last value set with amp. Recommended for PV charging.